### PR TITLE
docs: fix go install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ You have several options there:
 - install via [MacPorts](https://www.macports.org): `sudo port selfupdate && sudo port install k3d` (MacPorts is available for MacOS)
 - install via [AUR](https://aur.archlinux.org/) package [rancher-k3d-bin](https://aur.archlinux.org/packages/rancher-k3d-bin/): `yay -S rancher-k3d-bin`
 - grab a release from the [release tab](https://github.com/k3d-io/k3d/releases) and install it yourself.
-- install via go: `go install github.com/k3d-io/k3d@latest` (**Note**: this will give you unreleased/bleeding-edge changes)
+- install via go: `go install github.com/k3d-io/k3d/v5@latest` (**Note**: this will give you unreleased/bleeding-edge changes)
 - use [Chocolatey](https://chocolatey.org/): `choco install k3d` (Chocolatey package manager is available for Windows)
   - package source can be found in [erwinkersten/chocolatey-packages](https://github.com/erwinkersten/chocolatey-packages/tree/master/automatic/k3d)
 


### PR DESCRIPTION
<!-- 
Hi there, have an early THANK YOU for your contribution!
k3d is a community-driven project, so we really highly appreciate any support.
Please make sure, you've read our Code of Conduct and the Contributing Guidelines :)
- Code of Conduct: https://github.com/k3d-io/k3d/blob/main/CODE_OF_CONDUCT.md
- Contributing Guidelines: https://github.com/k3d-io/k3d/blob/main/CONTRIBUTING.md
-->

# What
fix go install command
<!-- What does this PR do or change? -->

# Why
`go install github.com/k3d-io/k3d@latest` failed
<!-- Link issues, discussions, etc. or just explain why you're creating this PR -->

# Implications
install v5 by default
<!--
Does this change existing behavior? If so, does it affect the CLI (cmd/) only or does it also/only change some internals of the Go module (pkg/)?
Especially mention breaking changes here!
-->

<!-- Get recognized using our all-contributors bot: https://github.com/k3d-io/k3d/blob/main/CONTRIBUTING.md#get-recognized -->
